### PR TITLE
Use classloader specified by the ClassLoadHelper

### DIFF
--- a/src/main/java/net/joelinn/quartz/jobstore/RedisJobStore.java
+++ b/src/main/java/net/joelinn/quartz/jobstore/RedisJobStore.java
@@ -139,6 +139,8 @@ public class RedisJobStore implements JobStore {
                 .addMixIn(HolidayCalendar.class, HolidayCalendarMixin.class)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
+        mapper.setTypeFactory(mapper.getTypeFactory().withClassLoader(loadHelper.getClassLoader()));
+
         if (redisCluster && jedisCluster == null) {
             Set<HostAndPort> nodes = buildNodesSetFromHost();
             JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();

--- a/src/main/java/net/joelinn/quartz/jobstore/RedisJobStore.java
+++ b/src/main/java/net/joelinn/quartz/jobstore/RedisJobStore.java
@@ -139,7 +139,9 @@ public class RedisJobStore implements JobStore {
                 .addMixIn(HolidayCalendar.class, HolidayCalendarMixin.class)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        mapper.setTypeFactory(mapper.getTypeFactory().withClassLoader(loadHelper.getClassLoader()));
+        if (loadHelper != null && loadHelper.getClassLoader() != null) {
+          mapper.setTypeFactory(mapper.getTypeFactory().withClassLoader(loadHelper.getClassLoader()));
+        }
 
         if (redisCluster && jedisCluster == null) {
             Set<HostAndPort> nodes = buildNodesSetFromHost();


### PR DESCRIPTION
Tell the ObjectMapper to use the ClassLoader specified in the ClassLoadHelper. This allows jobs to be written in Clojure for example by telling Quartz to use a custom ClassLoadHelper in `quartz.properties` and to create a ClassLoadHelper which uses Clojure's DynamicClassLoader.

I think the best solution would be to somehow use the ClassLoadHelper's `loadClass` method when loading classes (like Quartz's built in [JobStoreTX SQL store](https://github.com/quartz-scheduler/quartz/blob/0699df90bd224323312d976511c60fd3cc08b539/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/StdJDBCDelegate.java#L852)), but I don't see how to do that while using the FastXML ObjectMapper.

Using this version, along with setting `org.quartz.scheduler.classLoadHelper.class` in my `quartz.properties` makes my Clojure based jobs work.

What do you think?